### PR TITLE
External link available

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ To access R/Shiny app, go to
 [http://churchilldev.jax.org:49194/GFRcalc/](http://churchilldev.jax.org:49194/GFRcalc/)
 (JAX network only)
 
+[https://korstanjelab.jax.org/KorstanjeLab/GFRcalc/](https://korstanjelab.jax.org/KorstanjeLab/GFRcalc/)(External Access)
+
 To use the batch processing, collect all XLSX files into one folder and use `manual_mode.R` script (after modifying the first four lines)
 
 ### Files

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Hall, J. E., Guyton, A. C., & Farr, B. M. (1977). A single-injection method for 
 
 ### Acknowldgements and license
 
-GFRCalc was developed by [Petr Simecek](https://github.com/simecek) with a help of Susan Sheehan and [Yuka Takemon](https://github.com/ytakemon) for [Korstanje Lab](https://github.com/TheJacksonLaboratory/KorstanjeLab_Publications). It can be freely shared and distributed under [MIT license](LICENSE).
+GFRCalc was developed by [Petr Simecek](https://github.com/simecek) with a help of Susan Sheehan and [Yuka Takemon](https://github.com/ytakemon) for [Korstanje Lab](https://www.jax.org/research-and-faculty/research-labs/the-korstanje-lab). It can be freely shared and distributed under [MIT license](LICENSE).


### PR DESCRIPTION
Hi Petr,

Just wanted to give you a heads up that we've created an externally facing server to access the GFRcalc shiny app. I added a button to download an example sheet with instructions for filling out the excel sheet. This addition isn't reflected in this pull request but I can integrate it into this if you want later. 

Cheers,
Yuka